### PR TITLE
解决在windows置顶时闪烁

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -100,7 +100,7 @@ void MainWindow::reloadSetting()
     this->stayOnTop = setting.getBool(KEY_FLAGS_STAY_ON_TOP);
     if (this->stayOnTop)
     {
-        this->stayOnTopTimer->start(1000);
+        this->stayOnTopTimer->start(500);
     } else
     {
         this->stayOnTopTimer->stop();
@@ -213,10 +213,7 @@ void MainWindow::handleCommand(QString command)
 void MainWindow::handleRefreshStayOnTopFlag()
 {
 #   ifndef LINUX
-    setWindowFlag(Qt::WindowStaysOnTopHint, !this->stayOnTop);
-    setWindowFlag(Qt::WindowStaysOnTopHint, this->stayOnTop);
-    setWindowFlag(Qt::Tool, true);
-    setVisible(true);
+    raise();
 #   endif
 }
 


### PR DESCRIPTION
用raise()提升窗口Z顺序，不会闪烁，已测试